### PR TITLE
Add string based recipe for saw handle

### DIFF
--- a/Common/src/main/java/survivalistessentials/data/recipe/ISurvivalistEssentialsRecipeProvider.java
+++ b/Common/src/main/java/survivalistessentials/data/recipe/ISurvivalistEssentialsRecipeProvider.java
@@ -179,8 +179,18 @@ public interface ISurvivalistEssentialsRecipeProvider {
             .define('I', Items.STICK)
             .pattern("IS")
             .pattern(" I")
+            .group("saw_handles")
             .unlockedBy("has_plant_string", _has(plantString))
-            .save(recipeOutput);
+            .save(recipeOutput, prefix("saw_handle_with_plant_string").toString());
+        
+        ShapedRecipeBuilder.shaped(itemRegistry, RecipeCategory.TOOLS, SurvivalistEssentialsItems.SAW_HANDLE)
+            .define('S', Items.STRING)
+            .define('I', Items.STICK)
+            .pattern("IS")
+            .pattern(" I")
+            .group("saw_handles")
+            .unlockedBy("has_string", _has(Items.STRING))
+            .save(recipeOutput, prefix("saw_handle_with_string").toString());
 
         ShapedRecipeBuilder.shaped(itemRegistry, RecipeCategory.TOOLS, SurvivalistEssentialsItems.CRUDE_SAW)
             .define('H', SurvivalistEssentialsItems.SAW_HANDLE)

--- a/Fabric/src/generated/resources/data/survivalistessentials/advancement/recipes/tools/saw_handle_with_plant_string.json
+++ b/Fabric/src/generated/resources/data/survivalistessentials/advancement/recipes/tools/saw_handle_with_plant_string.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_plant_string": {
+      "conditions": {
+        "items": [
+          {
+            "items": "survivalistessentials:plant_string"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "survivalistessentials:saw_handle_with_plant_string"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_plant_string"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "survivalistessentials:saw_handle_with_plant_string"
+    ]
+  }
+}

--- a/Fabric/src/generated/resources/data/survivalistessentials/advancement/recipes/tools/saw_handle_with_string.json
+++ b/Fabric/src/generated/resources/data/survivalistessentials/advancement/recipes/tools/saw_handle_with_string.json
@@ -1,11 +1,11 @@
 {
   "parent": "minecraft:recipes/root",
   "criteria": {
-    "has_plant_string": {
+    "has_string": {
       "conditions": {
         "items": [
           {
-            "items": "survivalistessentials:plant_string"
+            "items": "minecraft:string"
           }
         ]
       },
@@ -13,7 +13,7 @@
     },
     "has_the_recipe": {
       "conditions": {
-        "recipe": "survivalistessentials:saw_handle"
+        "recipe": "survivalistessentials:saw_handle_with_string"
       },
       "trigger": "minecraft:recipe_unlocked"
     }
@@ -21,12 +21,12 @@
   "requirements": [
     [
       "has_the_recipe",
-      "has_plant_string"
+      "has_string"
     ]
   ],
   "rewards": {
     "recipes": [
-      "survivalistessentials:saw_handle"
+      "survivalistessentials:saw_handle_with_string"
     ]
   }
 }

--- a/Fabric/src/generated/resources/data/survivalistessentials/recipe/saw_handle_with_plant_string.json
+++ b/Fabric/src/generated/resources/data/survivalistessentials/recipe/saw_handle_with_plant_string.json
@@ -1,6 +1,7 @@
 {
   "type": "minecraft:crafting_shaped",
   "category": "equipment",
+  "group": "saw_handles",
   "key": {
     "I": "minecraft:stick",
     "S": "survivalistessentials:plant_string"

--- a/Fabric/src/generated/resources/data/survivalistessentials/recipe/saw_handle_with_string.json
+++ b/Fabric/src/generated/resources/data/survivalistessentials/recipe/saw_handle_with_string.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "group": "saw_handles",
+  "key": {
+    "I": "minecraft:stick",
+    "S": "minecraft:string"
+  },
+  "pattern": [
+    "IS",
+    " I"
+  ],
+  "result": {
+    "count": 1,
+    "id": "survivalistessentials:saw_handle"
+  }
+}


### PR DESCRIPTION
Playing with friends we noticed that if you die, the reusable saw handle needs to be crafted again using "early game" string equivalent. We do not see any reason for recipe not to accept ordinary minecraft string, which is also used when crafting more advanced saw blades in the mod.

If you dont feel like this is a good addition, i will just keep it on private fork, but thats entirely up to you.

I ran fabric datagen and already use fabric version myself but i dont know how to update the neoforge version, so this part needs to be finished by you.

Also i chose to conform with convention that each recipe for the same item has its own name starting with item name, so I renamed saw_handle recipe to saw_handle_with_plant_string causing the recipe to disapear if it was already added to recipe book. It should be possible to not rename original recipe and leave the recipe reasearched.